### PR TITLE
Update main.workflow

### DIFF
--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -1,18 +1,23 @@
-workflow "Build and test on push" {
+workflow "Build and Test" {
   on = "push"
-  resolves = ["Build and test"]
+  resolves = [
+    "Build and test",
+    "Build and deploy",
+  ]
 }
 
 action "Build and test" {
   uses = "./.github/build-and-test"
 }
 
-workflow "Deploy on release" {
-  on = "release"
-  resolves = ["Build and deploy"]
+action "Check Tag" {
+  uses = "actions/bin/filter@707718ee26483624de00bd146e073d915139a3d8"
+  needs = ["Build and test"]
+  args = "tag v*"
 }
 
 action "Build and deploy" {
   uses = "./.github/build-and-deploy"
+  needs = ["Check Tag"]
   secrets = ["NUGET_API_KEY", "NUGET_SERVER_URI"]
 }


### PR DESCRIPTION
As github actions is still in beta, the `on = "release"` does not work.
So now the current tag gets checked.